### PR TITLE
Implement Travis CI for testing with Docker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+sudo: required
+
+services:
+  - docker
+
+before_install:
+  - docker pull teichlab/bracer
+
+script:
+  - travis_wait 20 sleep 1200 & docker run -it --rm -v $PWD:/scratch -w /scratch teichlab/bracer test -o test_data
+  - diff ./test_data/expected_summary/BCR_summary.txt ./test_data/results/filtered_BCR_summary/BCR_summary.txt

--- a/bracerlib/tasks.py
+++ b/bracerlib/tasks.py
@@ -888,7 +888,7 @@ class Summariser(TracerTask):
             "It does not exclude cells that only share heavy chain and not "
             "light chain if Summarise is run with --IGH_networks.\n\n")
 
-        for g in component_groups:
+        for g in sorted(component_groups):
             outfile.write(", ".join(g))
             outfile.write("\n")
             
@@ -1823,7 +1823,7 @@ class Summariser(TracerTask):
         header = ("##Isotype of cells with productive heavy chain##\n\n"
                  + "Isotype\tcells\t% of cells\n")
         outstring = ""
-        for isotype, number in six.iteritems(isotype_counter):
+        for isotype, number in sorted(six.iteritems(isotype_counter)):
             number = str(number)
             percent = float(number)/int(prod_H)*100
             percent = format(percent, '.2f')


### PR DESCRIPTION
Hi @mstubb ,

This address #15 by pulling the Docker image, running the built-in test, and comparing the
summarized output to what is expected. The `travis_wait 20 sleep 1200 &` hack in `.travis.yml` is necessary because travis otherwise fails during assembly due to the lack of console output for over 10min while constructing the target De Bruijn graph within the `Kallisto [build]` command.

Right now the [build is failing](https://travis-ci.org/dcroote/bracer/builds/392907537) due to the fact that dictionaries are unordered, but this should be fixed once the Docker image is updated with the two included `sorted` additions to `bracerlib/tasks.py`.

If you like this, going forward it probably makes sense that you open a (free for open source) [travis-ci](https://travis-ci.org/) account and link to this repository so builds automatically occur after a push or pull request. Something similar could be implemented for tracer, and also include tracer's unit tests.

Best,
Derek