### PR TITLE
Fix sam to fastq read 2 write bug

### DIFF
--- a/bracerlib/bracer_func.py
+++ b/bracerlib/bracer_func.py
@@ -1676,7 +1676,7 @@ def split_sam_file_paired(sam_file, fasta=False):
                         name_ending = "/2"
                         if fasta==False:
                             fastq_lines_2.append(
-                                "@{name}{name_ending}\n{seq}\n+\en{qual}\n".format(
+                                "@{name}{name_ending}\n{seq}\n+\n{qual}\n".format(
                                 name=name, seq=seq, name_ending=name_ending, 
                                 qual=qual))
                         else:


### PR DESCRIPTION
This fixes a typo that affects the `+` line ending in read 2 fastqs.

For example, see:
https://github.com/Teichlab/bracer/blob/303b5101be27dc26c3a61592e38efe7c08abb923/test_data/results/cell2/aligned_reads/cell2_BCR_K_2.fastq#L1-L4